### PR TITLE
50 ref transformar o gamestate e game como variaveis globais

### DIFF
--- a/src/components/button.c
+++ b/src/components/button.c
@@ -2,7 +2,7 @@
 #include "../headers/helper.h"
 #include <allegro5/allegro_primitives.h>
 
-bool drawButton(struct Button *button, struct AllegroGame *game) {
+bool drawButton(struct Button *button) {
   int text_width = al_get_text_width(button->font, button->text);
   int text_height = al_get_font_line_height(button->font);
 
@@ -17,5 +17,5 @@ bool drawButton(struct Button *button, struct AllegroGame *game) {
     al_draw_text(button->font, button->font_color, text_x, text_y, ALLEGRO_ALIGN_CENTRE, button->text);
   }
 
-  return isMouseOverBox(game->mouse_state, button->x, button->y, button->width, button->height);
+  return isMouseOverBox(GAME_INFO->mouse_state, button->x, button->y, button->width, button->height);
 }

--- a/src/handle.c
+++ b/src/handle.c
@@ -2,54 +2,54 @@
 #include "headers/screens.h"
 #include "headers/helper.h"
 
-bool handleScrens (struct AllegroGame *game, GameState *gameState) {
+bool handleScrens () {
   bool redraw = true;
 
-  if (game->event.type == ALLEGRO_EVENT_TIMER)
+  if (GAME_INFO->event.type == ALLEGRO_EVENT_TIMER)
     redraw = true;
-  else if(game->event.type == ALLEGRO_EVENT_DISPLAY_CLOSE)
+  else if(GAME_INFO->event.type == ALLEGRO_EVENT_DISPLAY_CLOSE)
     return false;
 
-  if(game->event.type == ALLEGRO_EVENT_KEY_DOWN) {
-    if(game->event.keyboard.keycode == ALLEGRO_KEY_ESCAPE) {
-      if (*gameState >= STAGE_1 && *gameState <= STAGE_5) {
-        *gameState = MAP;
+  if(GAME_INFO->event.type == ALLEGRO_EVENT_KEY_DOWN) {
+    if(GAME_INFO->event.keyboard.keycode == ALLEGRO_KEY_ESCAPE) {
+      if (GAME_INFO->state >= STAGE_1 && GAME_INFO->state <= STAGE_5) {
+        GAME_INFO->state = MAP;
       } else {
-        *gameState = MENU;
+        GAME_INFO->state = MENU;
       }
     }
   }
 
-  if(redraw && al_is_event_queue_empty(game->queue)) {
+  if(redraw && al_is_event_queue_empty(GAME_INFO->queue)) {
     al_clear_to_color(AL_COLOR_BLACK);
 
-    switch (*gameState) {
+    switch (GAME_INFO->state) {
       case MENU:
-        if (!drawHome(game, gameState)) return false;
+        if (!drawHome()) return false;
         break;
       case CONFIG:
-        if (!drawConfig(game)) *gameState = MENU;
+        if (!drawConfig()) GAME_INFO->state = MENU;
         break;
       case GAME:
-        if (!drawGame(game)) *gameState = MENU;
+        if (!drawGame()) GAME_INFO->state = MENU;
         break;
       case MAP:
-        if(!drawMap(game,gameState)) *gameState = MENU;
+        if(!drawMap()) GAME_INFO->state = MENU;
         break;
       case STAGE_1:
-        if(!drawStage_1(game,gameState)) *gameState = MAP;
+        if(!drawStage_1()) GAME_INFO->state = MAP;
         break;
       case STAGE_2:
-        if(!drawStage_2(game,gameState)) *gameState = MAP;
+        if(!drawStage_2()) GAME_INFO->state = MAP;
         break;
       case STAGE_3:
-        if(!drawStage_3(game,gameState)) *gameState = MAP;
+        if(!drawStage_3()) GAME_INFO->state = MAP;
         break;
       case STAGE_4:
-        if(!drawStage_4(game,gameState)) *gameState = MAP;
+        if(!drawStage_4()) GAME_INFO->state = MAP;
         break;
       case STAGE_5:
-        if(!drawStage_5(game,gameState)) *gameState = MAP;
+        if(!drawStage_5()) GAME_INFO->state = MAP;
         break;
       default:
         break;

--- a/src/headers/components.h
+++ b/src/headers/components.h
@@ -29,6 +29,6 @@ extern struct Button BUTTONS_CONFIG[BUTTONS_CONFIG_COUNT];
 #define BUTTONS_HOME_COUNT 3
 extern struct Button BUTTONS_HOME[BUTTONS_HOME_COUNT];
 
-bool drawButton(struct Button *button, struct AllegroGame *game);
+bool drawButton(struct Button *button);
 
 #endif

--- a/src/headers/handle.h
+++ b/src/headers/handle.h
@@ -4,6 +4,6 @@
 #include <allegro5/allegro5.h>
 #include "helper.h"
 
-bool handleScrens (struct AllegroGame *game, GameState *gameState);
+bool handleScrens ();
 
 #endif

--- a/src/headers/helper.h
+++ b/src/headers/helper.h
@@ -50,31 +50,12 @@ struct AllegroGame {
   bool is_sound;
 };
 
-extern struct AllegroGame *game;
-
-struct Protagonista {
-  int x;
-  int y;
-  int width;
-  int height;
-  int speed;
-  int direction;
-  int lives;
-  int score;
-  int stageX;
-  int estagioAtual;
-  double last_shoot;
-  int bullets;
-  ALLEGRO_BITMAP *image;
-  ALLEGRO_BITMAP *image_bullet;
-};
-
 enum MENU_OPTIONS { START_GAME, SETTINGS, EXIT, NUM_OPTIONS };
 
 bool isMouseOverText(ALLEGRO_MOUSE_STATE *mouse_state, int text_x, int text_y, const char *text, ALLEGRO_FONT *font);
 
 bool isMouseOverBox(ALLEGRO_MOUSE_STATE *mouse_state, int box_x, int box_y, int box_width, int box_height);
 
-float changeScreen(struct Protagonista *protagonista, int totalStages);
+float changeScreen(int totalStages);
 
 #endif

--- a/src/headers/helper.h
+++ b/src/headers/helper.h
@@ -7,6 +7,8 @@
 extern int WIDTH_SCREEN;
 extern int HEIGHT_SCREEN;
 
+extern struct AllegroGame *GAME_INFO;
+
 #define FONT_PATH "assets/fonts/Roboto-Regular.ttf"
 #define FONT_SIZE 18
 #define FONT_SIZE_SMALL 14
@@ -22,6 +24,18 @@ extern int HEIGHT_SCREEN;
 #define AL_COLOR_LIGHT_BROWN al_map_rgb(214, 146, 68)
 #define AL_COLOR_DARK_BROWN al_map_rgb(102, 51, 0)
 
+typedef enum {
+  MENU = 0,
+  GAME = 1,
+  CONFIG = 2,
+  MAP = 3,
+  STAGE_1 = 4,
+  STAGE_2 = 5,
+  STAGE_3 = 6,
+  STAGE_4 = 7,
+  STAGE_5 = 8
+} GameState;
+
 struct AllegroGame {
   ALLEGRO_TIMER *timer;
   ALLEGRO_EVENT_QUEUE *queue;
@@ -32,8 +46,11 @@ struct AllegroGame {
   ALLEGRO_FONT *font_big;
   ALLEGRO_FONT *font_bullet;
   ALLEGRO_MOUSE_STATE *mouse_state;
+  GameState state;
   bool is_sound;
 };
+
+extern struct AllegroGame *game;
 
 struct Protagonista {
   int x;
@@ -54,23 +71,10 @@ struct Protagonista {
 
 enum MENU_OPTIONS { START_GAME, SETTINGS, EXIT, NUM_OPTIONS };
 
-typedef enum {
-  MENU = 0,
-  GAME = 1,
-  CONFIG = 2,
-  MAP = 3,
-  STAGE_1 = 4,
-  STAGE_2 = 5,
-  STAGE_3 = 6,
-  STAGE_4 = 7,
-  STAGE_5 = 8
-} GameState;
-
 bool isMouseOverText(ALLEGRO_MOUSE_STATE *mouse_state, int text_x, int text_y, const char *text, ALLEGRO_FONT *font);
 
 bool isMouseOverBox(ALLEGRO_MOUSE_STATE *mouse_state, int box_x, int box_y, int box_width, int box_height);
 
-//função que regula a troca de telas dentro do jogo, que recebe como parâmetro o protagonista e o total de estágios dentro de cada fase
-float changeScreen(struct Protagonista *protagonista, int totalStages, GameState *gamestate);
+float changeScreen(struct Protagonista *protagonista, int totalStages);
 
 #endif

--- a/src/headers/protagonista.h
+++ b/src/headers/protagonista.h
@@ -23,12 +23,12 @@ extern struct BulletProtagonista bullets_protagonista[BULLETS_PROTAGONISTA_COUNT
 
 void setupProtagonista(struct Protagonista *protagonista);
 void drawProtagonista(struct Protagonista *protagonista);
-void moveProtagonista(struct Protagonista *protagonista, struct AllegroGame *game);
+void moveProtagonista(struct Protagonista *protagonista);
 
-void drawBulletCount(int bullets, struct AllegroGame *game);
+void drawBulletCount(int bullets);
 void setupBulletsProtagonista();
-void shootProtagonista(struct Protagonista *protagonista, struct AllegroGame *game);
+void shootProtagonista(struct Protagonista *protagonista);
 
-void handlerProtagonista(struct Protagonista *protagonista, struct AllegroGame *game);
+void handlerProtagonista(struct Protagonista *protagonista);
 
 #endif

--- a/src/headers/protagonista.h
+++ b/src/headers/protagonista.h
@@ -15,20 +15,37 @@ struct BulletProtagonista {
   ALLEGRO_BITMAP *image;
 };
 
-extern struct Protagonista protagonista;
+struct Protagonista {
+  int x;
+  int y;
+  int width;
+  int height;
+  int speed;
+  int direction;
+  int lives;
+  int score;
+  int stageX;
+  int estagioAtual;
+  double last_shoot;
+  int bullets;
+  ALLEGRO_BITMAP *image;
+  ALLEGRO_BITMAP *image_bullet;
+};
+
+extern struct Protagonista *protagonista;
 
 #define BULLETS_PROTAGONISTA_COUNT 3
 #define SHOOT_DELAY 0.9
 extern struct BulletProtagonista bullets_protagonista[BULLETS_PROTAGONISTA_COUNT];
 
-void setupProtagonista(struct Protagonista *protagonista);
-void drawProtagonista(struct Protagonista *protagonista);
-void moveProtagonista(struct Protagonista *protagonista);
+void setupProtagonista();
+void drawProtagonista();
+void moveProtagonista();
 
 void drawBulletCount(int bullets);
 void setupBulletsProtagonista();
-void shootProtagonista(struct Protagonista *protagonista);
+void shootProtagonista();
 
-void handlerProtagonista(struct Protagonista *protagonista);
+void handlerProtagonista();
 
 #endif

--- a/src/headers/screens.h
+++ b/src/headers/screens.h
@@ -7,59 +7,59 @@
 #include "helper.h"
 
 extern ALLEGRO_BITMAP *bg_home;
-void setupHome(struct AllegroGame *game);
+void setupHome();
 void destroyHome(void);
-bool drawHome(struct AllegroGame *game, GameState *gameState);
+bool drawHome();
 
-bool drawConfig(struct AllegroGame *game);
+bool drawConfig();
 void destroyConfig(void);
-void setupButtonsConfig(struct AllegroGame *game);
+void setupButtonsConfig();
 
 extern ALLEGRO_BITMAP *bg_game;
 void setupGame();
 void destroyGame();
-bool drawGame(struct AllegroGame *game);
+bool drawGame();
 
 extern ALLEGRO_BITMAP *bg_map;
 void setupMap();
 void destroyMap();
-bool drawMap(struct AllegroGame *game, GameState *gameState);
+bool drawMap();
 
-extern struct MapProtagonista mapProtagonista;
 struct MapProtagonista {
   int x;
   float y;
   int stage;
   ALLEGRO_BITMAP *image;
 };
-void setupMapProtagonista(struct MapProtagonista *mapProtagonista);
-void destroyMapProtagonista(struct MapProtagonista *mapProtagonista);
-void drawMapProtagonista(struct MapProtagonista *mapProtagonista);
-void protagonistaMapMovement(struct AllegroGame *game, GameState *gameState, struct MapProtagonista *mapProtagonista);
+
+void setupMapProtagonista();
+void destroyMapProtagonista();
+void drawMapProtagonista();
+void protagonistaMapMovement();
 
 extern ALLEGRO_BITMAP *bg_stage_1;
 void setupStage_1();
 void destroyStage_1();
-bool drawStage_1(struct AllegroGame *game, GameState *gameState);
+bool drawStage_1();
 
 extern ALLEGRO_BITMAP *bg_stage_2;
 void setupStage_2();
 void destroyStage_2();
-bool drawStage_2(struct AllegroGame *game, GameState *gameState);
+bool drawStage_2();
 
 extern ALLEGRO_BITMAP *bg_stage_3;
 void setupStage_3();
 void destroyStage_3();
-bool drawStage_3(struct AllegroGame *game, GameState *gameState);
+bool drawStage_3();
 
 extern ALLEGRO_BITMAP *bg_stage_4;
 void setupStage_4();
 void destroyStage_4();
-bool drawStage_4(struct AllegroGame *game, GameState *gameState);
+bool drawStage_4();
 
 extern ALLEGRO_BITMAP *bg_stage_5;
 void setupStage_5();
 void destroyStage_5();
-bool drawStage_5(struct AllegroGame *game, GameState *gameState);
+bool drawStage_5();
 
 #endif

--- a/src/headers/sound.h
+++ b/src/headers/sound.h
@@ -13,7 +13,7 @@ typedef struct {
 #define MAX_SAMPLES 2
 extern Sample samples[MAX_SAMPLES];
 
-void playSound(struct AllegroGame *game, int sample_index);
+void playSound(int sample_index);
 
 void setupSamples(void);
 

--- a/src/headers/sound.h
+++ b/src/headers/sound.h
@@ -10,6 +10,11 @@ typedef struct {
   int id;
 } Sample;
 
+typedef enum {
+  MENU_CLICK = 0,
+  SHOOT = 1
+} SampleIndex;
+
 #define MAX_SAMPLES 2
 extern Sample samples[MAX_SAMPLES];
 

--- a/src/helper.c
+++ b/src/helper.c
@@ -1,4 +1,5 @@
 #include "headers/helper.h"
+#include "headers/protagonista.h"
 #include <stdio.h>
 #include <allegro5/allegro5.h>
 
@@ -24,7 +25,7 @@ bool isMouseOverBox(ALLEGRO_MOUSE_STATE *mouse_state, int box_x, int box_y, int 
   return (mouse_state->x >= box_x && mouse_state->x <= box_right && mouse_state->y >= box_y && mouse_state->y <= box_bottom);
 }
 
-float changeScreen(struct Protagonista *protagonista, int totalStages) {
+float changeScreen(int totalStages) {
   int stage;
   int a = 0;
 

--- a/src/helper.c
+++ b/src/helper.c
@@ -24,8 +24,7 @@ bool isMouseOverBox(ALLEGRO_MOUSE_STATE *mouse_state, int box_x, int box_y, int 
   return (mouse_state->x >= box_x && mouse_state->x <= box_right && mouse_state->y >= box_y && mouse_state->y <= box_bottom);
 }
 
-float changeScreen(struct Protagonista *protagonista, int totalStages, GameState *gamestate) {
-
+float changeScreen(struct Protagonista *protagonista, int totalStages) {
   int stage;
   int a = 0;
 
@@ -36,10 +35,10 @@ float changeScreen(struct Protagonista *protagonista, int totalStages, GameState
       protagonista->x = 0;
     }
      if(protagonista->stageX >= 7680) {
-        *gamestate = MAP;  // caso tenha acabado a fase, volta pro mapa
+        GAME_INFO->state = MAP;  // caso tenha acabado a fase, volta pro mapa
         protagonista->stageX = 0;
         protagonista->x = 0;
-      } 
+      }
 
   } else if(protagonista->stageX > WIDTH_SCREEN * 2 - (protagonista->width/3)) {
     stage = 2;

--- a/src/main.c
+++ b/src/main.c
@@ -13,7 +13,9 @@
 #include "headers/protagonista.h"
 #include "headers/enemies.h"
 
-void initializeAllegro(struct AllegroGame *game) {
+struct AllegroGame *GAME_INFO;
+
+void initializeAllegro() {
   ALLEGRO_MONITOR_INFO monitor_info;
 
   al_get_monitor_info(0, &monitor_info);
@@ -24,28 +26,36 @@ void initializeAllegro(struct AllegroGame *game) {
   int window_x = monitor_info.x1;
   int window_y = monitor_info.y1;
 
-  game->font = al_load_font(FONT_PATH, FONT_SIZE, 0);
-  game->font_small = al_load_font(FONT_PATH, FONT_SIZE_SMALL, 0);
-  game->font_big = al_load_font(FONT_PATH, FONT_SIZE_BIG, 0);
-  game->font_bullet = al_load_font(FONT_PATH, 50, 0);
+  GAME_INFO = (struct AllegroGame *) malloc(sizeof(struct AllegroGame));
+  GAME_INFO->state = MENU;
 
-  game->timer = al_create_timer(1.0 / 30.0);
-  game->queue = al_create_event_queue();
-  game->display = al_create_display(WIDTH_SCREEN, HEIGHT_SCREEN);
+  if (!GAME_INFO) {
+    fprintf(stderr, "Fail to allocate memory.\n");
+    exit(1);
+  }
 
-  al_set_window_position(game->display, window_x, window_y);
+  GAME_INFO->font = al_load_font(FONT_PATH, FONT_SIZE, 0);
+  GAME_INFO->font_small = al_load_font(FONT_PATH, FONT_SIZE_SMALL, 0);
+  GAME_INFO->font_big = al_load_font(FONT_PATH, FONT_SIZE_BIG, 0);
+  GAME_INFO->font_bullet = al_load_font(FONT_PATH, 50, 0);
 
-  game->mouse_state = (ALLEGRO_MOUSE_STATE *) malloc(sizeof(ALLEGRO_MOUSE_STATE));
+  GAME_INFO->timer = al_create_timer(1.0 / 30.0);
+  GAME_INFO->queue = al_create_event_queue();
+  GAME_INFO->display = al_create_display(WIDTH_SCREEN, HEIGHT_SCREEN);
 
-  game->is_sound = true;
+  al_set_window_position(GAME_INFO->display, window_x, window_y);
 
-  if (!game->timer || !game->queue || !game->display) {
-    fprintf(stderr, "Falha to load Allegro.\n");
+  GAME_INFO->mouse_state = (ALLEGRO_MOUSE_STATE *) malloc(sizeof(ALLEGRO_MOUSE_STATE));
+
+  GAME_INFO->is_sound = true;
+
+  if (!GAME_INFO->timer || !GAME_INFO->queue || !GAME_INFO->display) {
+    fprintf(stderr, "Fail to load Allegro.\n");
     exit(1);
   }
 }
 
-void setupAllegro(struct AllegroGame *game) {
+void setupAllegro() {
   al_init();
   al_install_keyboard();
   al_init_image_addon();
@@ -56,30 +66,30 @@ void setupAllegro(struct AllegroGame *game) {
   al_install_audio();
   al_init_acodec_addon();
 
-  initializeAllegro(game);
+  initializeAllegro();
 
-  if (!game->timer || !game->queue || !game->display) {
-    fprintf(stderr, "Falha to load Allegro.\n");
+  if (!GAME_INFO->timer || !GAME_INFO->queue || !GAME_INFO->display) {
+    fprintf(stderr, "Fail to load Allegro.\n");
     exit(1);
   }
 
-  al_register_event_source(game->queue, al_get_keyboard_event_source());
-  al_register_event_source(game->queue, al_get_display_event_source(game->display));
-  al_register_event_source(game->queue, al_get_timer_event_source(game->timer));
-  al_register_event_source(game->queue, al_get_mouse_event_source());
+  al_register_event_source(GAME_INFO->queue, al_get_keyboard_event_source());
+  al_register_event_source(GAME_INFO->queue, al_get_display_event_source(GAME_INFO->display));
+  al_register_event_source(GAME_INFO->queue, al_get_timer_event_source(GAME_INFO->timer));
+  al_register_event_source(GAME_INFO->queue, al_get_mouse_event_source());
 
-  al_set_window_title(game->display, "Sombras do Sertão");
-  al_set_display_icon(game->display, al_load_bitmap("assets/images/icon/icon.jpeg"));
+  al_set_window_title(GAME_INFO->display, "Sombras do Sertão");
+  al_set_display_icon(GAME_INFO->display, al_load_bitmap("assets/images/icon/icon.jpeg"));
 
   setupSamples();
 
   setupProtagonista(&protagonista);
   setupBulletsProtagonista();
-  setupMapProtagonista(&mapProtagonista);
+  setupMapProtagonista();
   setupEnemies();
   setupBulletEnemies();
-  setupButtonsConfig(game);
-  setupHome(game);
+  setupButtonsConfig();
+  setupHome();
   setupGame();
   setupMap();
   setupStage_1();
@@ -89,15 +99,15 @@ void setupAllegro(struct AllegroGame *game) {
   setupStage_5();
 }
 
-void destroyAllegro(struct AllegroGame *game) {
-  al_destroy_font(game->font);
-  al_destroy_font(game->font_small);
-  al_destroy_font(game->font_big);
-  al_destroy_font(game->font_bullet);
+void destroyAllegro() {
+  al_destroy_font(GAME_INFO->font);
+  al_destroy_font(GAME_INFO->font_small);
+  al_destroy_font(GAME_INFO->font_big);
+  al_destroy_font(GAME_INFO->font_bullet);
   
-  al_destroy_display(game->display);
-  al_destroy_timer(game->timer);
-  al_destroy_event_queue(game->queue);
+  al_destroy_display(GAME_INFO->display);
+  al_destroy_timer(GAME_INFO->timer);
+  al_destroy_event_queue(GAME_INFO->queue);
 
   al_uninstall_audio();
   al_uninstall_keyboard();
@@ -113,41 +123,38 @@ void destroyAllegro(struct AllegroGame *game) {
   destroyConfig();
   destroyGame();
   destroyMap();
-  destroyMapProtagonista(&mapProtagonista);
+  destroyMapProtagonista();
   destroyStage_1();
   destroyStage_2();
   destroyStage_3();
   destroyStage_4();
   destroyStage_5();
-  free(game->mouse_state);
-  free(game);
+  free(GAME_INFO->mouse_state);
+  free(GAME_INFO);
 }
 
 int main() {
-  struct AllegroGame *game = (struct AllegroGame *) malloc(sizeof(struct AllegroGame));
-  GameState gameState = MENU;
-
-  setupAllegro(game);
+  setupAllegro();
 
   bool redraw = true;
 
-  al_start_timer(game->timer);
+  al_start_timer(GAME_INFO->timer);
   bool done = false;
 
   while(!done) {
-    al_wait_for_event(game->queue, &game->event);
-    al_get_mouse_state(game->mouse_state);
+    al_wait_for_event(GAME_INFO->queue, &GAME_INFO->event);
+    al_get_mouse_state(GAME_INFO->mouse_state);
 
-    if (!handleScrens(game, &gameState)) {
+    if (!handleScrens()) {
       done = true;
     }
 
-    if (game->event.type == ALLEGRO_EVENT_DISPLAY_CLOSE) {
+    if (GAME_INFO->event.type == ALLEGRO_EVENT_DISPLAY_CLOSE) {
       done = true;
     }
   }
 
-  destroyAllegro(game);
+  destroyAllegro(GAME_INFO);
 
   return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -83,7 +83,7 @@ void setupAllegro() {
 
   setupSamples();
 
-  setupProtagonista(&protagonista);
+  setupProtagonista();
   setupBulletsProtagonista();
   setupMapProtagonista();
   setupEnemies();

--- a/src/protagonista.c
+++ b/src/protagonista.c
@@ -8,10 +8,12 @@
 #include <allegro5/allegro_image.h>
 #include <allegro5/allegro_primitives.h>
 
-struct Protagonista protagonista;
 struct BulletProtagonista bullets_protagonista[BULLETS_PROTAGONISTA_COUNT];
+struct Protagonista *protagonista;
 
-void setupProtagonista(struct Protagonista *protagonista) {
+void setupProtagonista() {
+  protagonista = malloc(sizeof(struct Protagonista));
+
   protagonista->x = 20;
   protagonista->y = HEIGHT_SCREEN / 2;
   protagonista->width = 250;
@@ -28,11 +30,11 @@ void setupProtagonista(struct Protagonista *protagonista) {
   protagonista->image_bullet = al_load_bitmap("assets/images/addons/ammo.png");
 }
 
-void drawProtagonista(struct Protagonista *protagonista) {
+void drawProtagonista() {
   al_draw_bitmap(protagonista->image, protagonista->x, protagonista->y, 0);
 }
 
-void moveProtagonista(struct Protagonista *protagonista) {
+void moveProtagonista() {
   int keycode = GAME_INFO->event.keyboard.keycode;
 
     switch (keycode) {
@@ -71,7 +73,7 @@ void setupBulletsProtagonista() {
   }
 }
 
-void shootProtagonista(struct Protagonista *protagonista) {
+void shootProtagonista() {
   double current_time = al_get_time();
 
   if (GAME_INFO->event.keyboard.keycode == ALLEGRO_KEY_SPACE && 
@@ -123,11 +125,11 @@ void shootProtagonista(struct Protagonista *protagonista) {
 }
 
 void drawBulletCount(int bullets) {
-  al_draw_bitmap(protagonista.image_bullet, 0, 10, 0);
+  al_draw_bitmap(protagonista->image_bullet, 0, 10, 0);
   al_draw_textf(GAME_INFO->font_bullet, AL_COLOR_BLACK, 100, 25, ALLEGRO_ALIGN_LEFT, "%d", bullets);
 }
 
-void handlerProtagonista(struct Protagonista *protagonista) {
+void handlerProtagonista() {
   drawBulletCount(protagonista->bullets);
   drawProtagonista(protagonista);
   moveProtagonista(protagonista);

--- a/src/protagonista.c
+++ b/src/protagonista.c
@@ -87,7 +87,7 @@ void shootProtagonista(struct Protagonista *protagonista) {
         protagonista->last_shoot = current_time;
         protagonista->bullets--;
 
-        playSound(1);
+        playSound(SHOOT);
         break;
       }
     }

--- a/src/protagonista.c
+++ b/src/protagonista.c
@@ -32,8 +32,8 @@ void drawProtagonista(struct Protagonista *protagonista) {
   al_draw_bitmap(protagonista->image, protagonista->x, protagonista->y, 0);
 }
 
-void moveProtagonista(struct Protagonista *protagonista, struct AllegroGame *game) {
-  int keycode = game->event.keyboard.keycode;
+void moveProtagonista(struct Protagonista *protagonista) {
+  int keycode = GAME_INFO->event.keyboard.keycode;
 
     switch (keycode) {
       case ALLEGRO_KEY_UP:
@@ -71,10 +71,10 @@ void setupBulletsProtagonista() {
   }
 }
 
-void shootProtagonista(struct Protagonista *protagonista, struct AllegroGame *game) {
+void shootProtagonista(struct Protagonista *protagonista) {
   double current_time = al_get_time();
 
-  if (game->event.keyboard.keycode == ALLEGRO_KEY_SPACE && 
+  if (GAME_INFO->event.keyboard.keycode == ALLEGRO_KEY_SPACE && 
       current_time - protagonista->last_shoot >= SHOOT_DELAY && 
       protagonista->bullets > 0
     ) {
@@ -87,7 +87,7 @@ void shootProtagonista(struct Protagonista *protagonista, struct AllegroGame *ga
         protagonista->last_shoot = current_time;
         protagonista->bullets--;
 
-        playSound(game, 1);
+        playSound(1);
         break;
       }
     }
@@ -122,14 +122,14 @@ void shootProtagonista(struct Protagonista *protagonista, struct AllegroGame *ga
   }
 }
 
-void drawBulletCount(int bullets, struct AllegroGame *game) {
+void drawBulletCount(int bullets) {
   al_draw_bitmap(protagonista.image_bullet, 0, 10, 0);
-  al_draw_textf(game->font_bullet, AL_COLOR_BLACK, 100, 25, ALLEGRO_ALIGN_LEFT, "%d", bullets);
+  al_draw_textf(GAME_INFO->font_bullet, AL_COLOR_BLACK, 100, 25, ALLEGRO_ALIGN_LEFT, "%d", bullets);
 }
 
-void handlerProtagonista(struct Protagonista *protagonista, struct AllegroGame *game) {
-  drawBulletCount(protagonista->bullets, game);
+void handlerProtagonista(struct Protagonista *protagonista) {
+  drawBulletCount(protagonista->bullets);
   drawProtagonista(protagonista);
-  moveProtagonista(protagonista, game);
-  shootProtagonista(protagonista, game);
+  moveProtagonista(protagonista);
+  shootProtagonista(protagonista);
 }

--- a/src/screens/config.c
+++ b/src/screens/config.c
@@ -50,7 +50,7 @@ bool drawConfig () {
 
       if (GAME_INFO->event.type == ALLEGRO_EVENT_MOUSE_BUTTON_UP) {
         printf("%s clicked\n", BUTTONS_CONFIG[i].text);
-        playSound(0);
+        playSound(MENU_CLICK);
 
         switch (i) {
           case 0:

--- a/src/screens/config.c
+++ b/src/screens/config.c
@@ -7,7 +7,7 @@ struct Button BUTTONS_CONFIG[BUTTONS_CONFIG_COUNT];
 
 ALLEGRO_FONT *fontSettings;
 
-void setupButtonsConfig(struct AllegroGame *game) {
+void setupButtonsConfig() {
   fontSettings = al_load_font("assets/fonts/LilitaOne-Regular.ttf",32,0);
   int width = 335;
   int height = 65;
@@ -41,25 +41,25 @@ void setupButtonsConfig(struct AllegroGame *game) {
   BUTTONS_CONFIG[1] = back;
 }
 
-bool drawConfig (struct AllegroGame *game) {
+bool drawConfig () {
   al_draw_bitmap(bg_home, 0, 0, 0);
 
   for (int i = 0; i < BUTTONS_CONFIG_COUNT; i++) {
-    if (drawButton(&BUTTONS_CONFIG[i], game)) {
+    if (drawButton(&BUTTONS_CONFIG[i])) {
       BUTTONS_CONFIG[i].background_color = AL_COLOR_LIGHT_BROWN;
 
-      if (game->event.type == ALLEGRO_EVENT_MOUSE_BUTTON_UP) {
+      if (GAME_INFO->event.type == ALLEGRO_EVENT_MOUSE_BUTTON_UP) {
         printf("%s clicked\n", BUTTONS_CONFIG[i].text);
-        playSound(game, 0);
+        playSound(0);
 
         switch (i) {
           case 0:
-            if (game->is_sound) {
+            if (GAME_INFO->is_sound) {
               BUTTONS_CONFIG[i].text = "Som: Desligado";
-              game->is_sound = false;
+              GAME_INFO->is_sound = false;
             } else {
               BUTTONS_CONFIG[i].text = "Som: Ligado";
-              game->is_sound = true;
+              GAME_INFO->is_sound = true;
             }
             break;
           case 1:

--- a/src/screens/game.c
+++ b/src/screens/game.c
@@ -15,10 +15,10 @@ void destroyGame () {
   al_destroy_bitmap(bg_game);
 }
 
-bool drawGame (struct AllegroGame *game) {
+bool drawGame () {
   al_draw_bitmap(bg_game, 0, 0, 0);
   
-  handlerProtagonista(&protagonista, game);
+  handlerProtagonista(&protagonista);
   handlerEnemies();
 
   return true;

--- a/src/screens/game.c
+++ b/src/screens/game.c
@@ -18,7 +18,7 @@ void destroyGame () {
 bool drawGame () {
   al_draw_bitmap(bg_game, 0, 0, 0);
   
-  handlerProtagonista(&protagonista);
+  handlerProtagonista();
   handlerEnemies();
 
   return true;

--- a/src/screens/home.c
+++ b/src/screens/home.c
@@ -82,7 +82,7 @@ bool drawHome () {
 
       if (GAME_INFO->event.type == ALLEGRO_EVENT_MOUSE_BUTTON_UP) {
         printf("%s clicked\n", BUTTONS_HOME[i].text);
-        playSound(0);
+        playSound(MENU_CLICK);
 
         switch (i) {
           case START_GAME:

--- a/src/screens/home.c
+++ b/src/screens/home.c
@@ -10,7 +10,7 @@ ALLEGRO_BITMAP *bg_home;
 ALLEGRO_FONT *fontHome;
 ALLEGRO_FONT *fontButton;
 
-void setupHome(struct AllegroGame *game) {
+void setupHome() {
   bg_home = al_load_bitmap("assets/images/background/bg_home.jpg");
   fontButton = al_load_font("assets/fonts/LilitaOne-Regular.ttf", 32, 0);
   fontHome = al_load_font("assets/fonts/LilitaOne-Regular.ttf", 64, 0);
@@ -67,7 +67,7 @@ void destroyHome(void) {
   al_destroy_font(fontHome);
 }
 
-bool drawHome (struct AllegroGame *game, GameState *gameState) {
+bool drawHome () {
   al_draw_bitmap(bg_home, 0, 0, 0);
 
   const char *title = "Sombras do Sertão";
@@ -77,21 +77,21 @@ bool drawHome (struct AllegroGame *game, GameState *gameState) {
   al_draw_text(fontHome, AL_COLOR_WHITE, title_x, title_y, ALLEGRO_ALIGN_CENTER, title);
 
   for (int i = 0; i < BUTTONS_HOME_COUNT; i++) {
-    if (drawButton(&BUTTONS_HOME[i], game)) {
+    if (drawButton(&BUTTONS_HOME[i])) {
       BUTTONS_HOME[i].background_color = AL_COLOR_LIGHT_BROWN;
 
-      if (game->event.type == ALLEGRO_EVENT_MOUSE_BUTTON_UP) {
+      if (GAME_INFO->event.type == ALLEGRO_EVENT_MOUSE_BUTTON_UP) {
         printf("%s clicked\n", BUTTONS_HOME[i].text);
-        playSound(game, 0);
+        playSound(0);
 
         switch (i) {
           case START_GAME:
             printf("Iniciar Jogo\n");
-            *gameState = MAP;
+            GAME_INFO->state = MAP;
             break;
           case SETTINGS:
             printf("Configurações\n");
-            *gameState = CONFIG;
+            GAME_INFO->state = CONFIG;
             break;
           case EXIT:
             return false;

--- a/src/screens/map.c
+++ b/src/screens/map.c
@@ -110,6 +110,8 @@ void protagonistaMapMovement() {
   case ALLEGRO_KEY_LEFT:
   case ALLEGRO_KEY_A:
     
+    if (mapProtagonista->stage == 0) return;
+
     mapProtagonista->stage--;
 
     switch (mapProtagonista->stage) {
@@ -151,6 +153,8 @@ void protagonistaMapMovement() {
     break;
   case ALLEGRO_KEY_RIGHT:
   case ALLEGRO_KEY_D:
+
+    if (mapProtagonista->stage == 8) return;
 
     mapProtagonista->stage++;
  

--- a/src/screens/map.c
+++ b/src/screens/map.c
@@ -194,27 +194,27 @@ void protagonistaMapMovement() {
   case ALLEGRO_KEY_ENTER:
     switch (mapProtagonista->stage) {
     case 0:
-      setupProtagonista(&protagonista);
+      setupProtagonista();
       setupEnemies(); 
       GAME_INFO->state = STAGE_1;
       break;
     case 2:
-      setupProtagonista(&protagonista);
+      setupProtagonista();
       setupEnemies(); 
       GAME_INFO->state = STAGE_2;
       break;
     case 4:
-      setupProtagonista(&protagonista);
+      setupProtagonista();
       setupEnemies(); 
       GAME_INFO->state = STAGE_3;
       break;
     case 6:
-      setupProtagonista(&protagonista);
+      setupProtagonista();
       setupEnemies(); 
       GAME_INFO->state = STAGE_4;
       break;
     case 8:     
-      setupProtagonista(&protagonista);
+      setupProtagonista();
       setupEnemies(); 
       GAME_INFO->state = STAGE_5;
       break;

--- a/src/screens/map.c
+++ b/src/screens/map.c
@@ -7,14 +7,15 @@
 #include <stdio.h>
 
 ALLEGRO_BITMAP *bg_map;
+struct MapProtagonista *mapProtagonista;
 
 void setupMap() {
   bg_map = al_load_bitmap("assets/images/background/bg_map.jpg");
 }
 
-struct MapProtagonista mapProtagonista;
+void setupMapProtagonista () {
+  mapProtagonista = (struct MapProtagonista *) malloc(sizeof(struct MapProtagonista));
 
-void setupMapProtagonista (struct MapProtagonista *mapProtagonista) {
   mapProtagonista->x = 147;
   mapProtagonista->y = 327;
   mapProtagonista->stage = 0;
@@ -25,18 +26,18 @@ void destroyMap() {
   al_destroy_bitmap(bg_map);
 }
 
-void destroyMapProtagonista(struct MapProtagonista *mapProtagonista) {
+void destroyMapProtagonista() {
   al_destroy_bitmap(mapProtagonista->image);
 }
 
-void passFrame(struct MapProtagonista *mapProtagonista) {
+void passFrame() {
   al_rest(0.001);
   al_draw_bitmap(bg_map, 0, 0, 0);
   drawMapProtagonista(mapProtagonista);
   al_flip_display();
 }
 
-void protagonistaMovement(int finalX, int finalY, struct MapProtagonista *mapProtagonista) {
+void protagonistaMovement(int finalX, int finalY) {
   int x = finalX - mapProtagonista->x;
   float y = finalY - mapProtagonista->y; 
 
@@ -102,8 +103,8 @@ void protagonistaMovement(int finalX, int finalY, struct MapProtagonista *mapPro
   }
 }
 
-void protagonistaMapMovement(struct AllegroGame *game, GameState *gameState, struct MapProtagonista *mapProtagonista) {
-  int keycode = game->event.keyboard.keycode;
+void protagonistaMapMovement() {
+  int keycode = GAME_INFO->event.keyboard.keycode;
 
   switch (keycode) {
   case ALLEGRO_KEY_LEFT:
@@ -111,40 +112,38 @@ void protagonistaMapMovement(struct AllegroGame *game, GameState *gameState, str
     
     mapProtagonista->stage--;
 
-    // Refazer usando for
-     
     switch (mapProtagonista->stage) {
     case 0:
-      protagonistaMovement(297, 327, mapProtagonista);
-      protagonistaMovement(147, 327, mapProtagonista);
+      protagonistaMovement(297, 327);
+      protagonistaMovement(147, 327);
       break;
     case 1:
-      protagonistaMovement(419, 694, mapProtagonista);
-      protagonistaMovement(353, 495, mapProtagonista);
+      protagonistaMovement(419, 694);
+      protagonistaMovement(353, 495);
       break;
     case 2:
-      protagonistaMovement(676, 694, mapProtagonista);
-      protagonistaMovement(550, 694, mapProtagonista);
+      protagonistaMovement(676, 694);
+      protagonistaMovement(550, 694);
       break;
     case 3:
-      protagonistaMovement(861, 269, mapProtagonista);
-      protagonistaMovement(771, 475, mapProtagonista);
+      protagonistaMovement(861, 269);
+      protagonistaMovement(771, 475);
       break; 
     case 4:
-      protagonistaMovement(1074, 269, mapProtagonista);
-      protagonistaMovement(962, 269, mapProtagonista);    
+      protagonistaMovement(1074, 269);
+      protagonistaMovement(962, 269);    
       break;
     case 5:
-      protagonistaMovement(1096, 505, mapProtagonista);
+      protagonistaMovement(1096, 505);
       break;
     case 6:
-      protagonistaMovement(1555, 476, mapProtagonista);
-      protagonistaMovement(1504, 505, mapProtagonista);
-      protagonistaMovement(1329, 505, mapProtagonista);
+      protagonistaMovement(1555, 476);
+      protagonistaMovement(1504, 505);
+      protagonistaMovement(1329, 505);
       break;
     case 7:
-      protagonistaMovement(1589, 392, mapProtagonista);
-      protagonistaMovement(1571, 436, mapProtagonista);
+      protagonistaMovement(1589, 392);
+      protagonistaMovement(1571, 436);
       break;
     default:
       break;
@@ -157,36 +156,36 @@ void protagonistaMapMovement(struct AllegroGame *game, GameState *gameState, str
  
     switch (mapProtagonista->stage) {
     case 1:
-      protagonistaMovement(297, 327, mapProtagonista);
-      protagonistaMovement(353, 495, mapProtagonista);
+      protagonistaMovement(297, 327);
+      protagonistaMovement(353, 495);
       break;
     case 2:
-      protagonistaMovement(419, 694, mapProtagonista);
-      protagonistaMovement(550, 694, mapProtagonista);
+      protagonistaMovement(419, 694);
+      protagonistaMovement(550, 694);
       break;
     case 3:
-      protagonistaMovement(676, 694, mapProtagonista);
-      protagonistaMovement(771, 475, mapProtagonista);
+      protagonistaMovement(676, 694);
+      protagonistaMovement(771, 475);
       break;
     case 4:
-      protagonistaMovement(861, 269, mapProtagonista);
-      protagonistaMovement(962, 269, mapProtagonista);
+      protagonistaMovement(861, 269);
+      protagonistaMovement(962, 269);
       break;
     case 5:
-      protagonistaMovement(1074, 269, mapProtagonista);
-      protagonistaMovement(1096, 505, mapProtagonista);
+      protagonistaMovement(1074, 269);
+      protagonistaMovement(1096, 505);
       break;
     case 6:
-      protagonistaMovement(1329, 505, mapProtagonista);
+      protagonistaMovement(1329, 505);
       break;
     case 7:
-      protagonistaMovement(1504, 505, mapProtagonista);
-      protagonistaMovement(1555, 476, mapProtagonista);
-      protagonistaMovement(1571, 436, mapProtagonista);
+      protagonistaMovement(1504, 505);
+      protagonistaMovement(1555, 476);
+      protagonistaMovement(1571, 436);
       break;
     case 8:
-      protagonistaMovement(1589, 392, mapProtagonista);
-      protagonistaMovement(1589, 169, mapProtagonista);
+      protagonistaMovement(1589, 392);
+      protagonistaMovement(1589, 169);
       break;
     default:
       break;
@@ -197,27 +196,27 @@ void protagonistaMapMovement(struct AllegroGame *game, GameState *gameState, str
     case 0:
       setupProtagonista(&protagonista);
       setupEnemies(); 
-      *gameState = STAGE_1;
+      GAME_INFO->state = STAGE_1;
       break;
     case 2:
       setupProtagonista(&protagonista);
       setupEnemies(); 
-      *gameState = STAGE_2;
+      GAME_INFO->state = STAGE_2;
       break;
     case 4:
       setupProtagonista(&protagonista);
       setupEnemies(); 
-      *gameState = STAGE_3;
+      GAME_INFO->state = STAGE_3;
       break;
     case 6:
       setupProtagonista(&protagonista);
       setupEnemies(); 
-      *gameState = STAGE_4;
+      GAME_INFO->state = STAGE_4;
       break;
     case 8:     
       setupProtagonista(&protagonista);
       setupEnemies(); 
-      *gameState = STAGE_5;
+      GAME_INFO->state = STAGE_5;
       break;
     default:
       break;  
@@ -228,14 +227,14 @@ void protagonistaMapMovement(struct AllegroGame *game, GameState *gameState, str
   }
 }
 
-void drawMapProtagonista (struct MapProtagonista *mapProtagonista) {
+void drawMapProtagonista () {
   al_draw_bitmap(mapProtagonista->image, mapProtagonista->x, mapProtagonista->y, 0);
 }
 
-bool drawMap(struct AllegroGame *game, GameState *gameState) {
+bool drawMap() {
   al_draw_bitmap(bg_map, 0, 0, 0);
-  drawMapProtagonista(&mapProtagonista);
-  protagonistaMapMovement(game, gameState, &mapProtagonista);
+  drawMapProtagonista();
+  protagonistaMapMovement();
 
   return true;
 }

--- a/src/screens/stage_1.c
+++ b/src/screens/stage_1.c
@@ -20,9 +20,9 @@ e o personagem é desenhado no xDoFrame*/
 
 
 bool drawStage_1 () {
-  al_draw_bitmap_region(bg_stage_1, changeScreen(&protagonista, 4) * WIDTH_SCREEN, 0, WIDTH_SCREEN, 1080, 0, 0, 0);
+  al_draw_bitmap_region(bg_stage_1, changeScreen(4) * WIDTH_SCREEN, 0, WIDTH_SCREEN, 1080, 0, 0, 0);
   
-  handlerProtagonista(&protagonista);
+  handlerProtagonista();
   handlerEnemies();
 
   return true;

--- a/src/screens/stage_1.c
+++ b/src/screens/stage_1.c
@@ -19,10 +19,10 @@ void destroyStage_1 () {
 e o personagem é desenhado no xDoFrame*/
 
 
-bool drawStage_1 (struct AllegroGame *game, GameState *gameState) {
-  al_draw_bitmap_region(bg_stage_1, changeScreen(&protagonista, 4, gameState) * WIDTH_SCREEN, 0, WIDTH_SCREEN, 1080, 0, 0, 0);
+bool drawStage_1 () {
+  al_draw_bitmap_region(bg_stage_1, changeScreen(&protagonista, 4) * WIDTH_SCREEN, 0, WIDTH_SCREEN, 1080, 0, 0, 0);
   
-  handlerProtagonista(&protagonista, game);
+  handlerProtagonista(&protagonista);
   handlerEnemies();
 
   return true;

--- a/src/screens/stage_2.c
+++ b/src/screens/stage_2.c
@@ -16,9 +16,9 @@ void destroyStage_2 () {
 }
 
 bool drawStage_2 () {
-  al_draw_bitmap_region(bg_stage_2, changeScreen(&protagonista, 4) * WIDTH_SCREEN , 0, WIDTH_SCREEN, 1080, 0, 0, 0);
+  al_draw_bitmap_region(bg_stage_2, changeScreen(4) * WIDTH_SCREEN , 0, WIDTH_SCREEN, 1080, 0, 0, 0);
   
-  handlerProtagonista(&protagonista);
+  handlerProtagonista();
   handlerEnemies();
 
   return true;

--- a/src/screens/stage_2.c
+++ b/src/screens/stage_2.c
@@ -15,11 +15,10 @@ void destroyStage_2 () {
   al_destroy_bitmap(bg_stage_2);
 }
 
-bool drawStage_2 (struct AllegroGame *game, GameState *gameState) {
- 
-  al_draw_bitmap_region(bg_stage_2, changeScreen(&protagonista, 4, gameState) * WIDTH_SCREEN , 0, WIDTH_SCREEN, 1080, 0, 0, 0);
+bool drawStage_2 () {
+  al_draw_bitmap_region(bg_stage_2, changeScreen(&protagonista, 4) * WIDTH_SCREEN , 0, WIDTH_SCREEN, 1080, 0, 0, 0);
   
-  handlerProtagonista(&protagonista, game);
+  handlerProtagonista(&protagonista);
   handlerEnemies();
 
   return true;

--- a/src/screens/stage_3.c
+++ b/src/screens/stage_3.c
@@ -16,9 +16,9 @@ void destroyStage_3 () {
 }
 
 bool drawStage_3 () {
-  al_draw_bitmap_region(bg_stage_3, changeScreen(&protagonista, 4) * WIDTH_SCREEN , 0, WIDTH_SCREEN, 1080, 0, 0, 0);
+  al_draw_bitmap_region(bg_stage_3, changeScreen(4) * WIDTH_SCREEN , 0, WIDTH_SCREEN, 1080, 0, 0, 0);
   
-  handlerProtagonista(&protagonista);
+  handlerProtagonista();
   handlerEnemies();
 
   return true;

--- a/src/screens/stage_3.c
+++ b/src/screens/stage_3.c
@@ -15,10 +15,10 @@ void destroyStage_3 () {
   al_destroy_bitmap(bg_stage_3);
 }
 
-bool drawStage_3 (struct AllegroGame *game, GameState *gameState) {
-  al_draw_bitmap_region(bg_stage_3, changeScreen(&protagonista, 4, gameState) * WIDTH_SCREEN , 0, WIDTH_SCREEN, 1080, 0, 0, 0);
+bool drawStage_3 () {
+  al_draw_bitmap_region(bg_stage_3, changeScreen(&protagonista, 4) * WIDTH_SCREEN , 0, WIDTH_SCREEN, 1080, 0, 0, 0);
   
-  handlerProtagonista(&protagonista, game);
+  handlerProtagonista(&protagonista);
   handlerEnemies();
 
   return true;

--- a/src/screens/stage_4.c
+++ b/src/screens/stage_4.c
@@ -16,9 +16,9 @@ void destroyStage_4 () {
 }
 
 bool drawStage_4 () {
-  al_draw_bitmap_region(bg_stage_4, changeScreen(&protagonista, 4) * WIDTH_SCREEN , 0, WIDTH_SCREEN, 1080, 0, 0, 0);
+  al_draw_bitmap_region(bg_stage_4, changeScreen(4) * WIDTH_SCREEN , 0, WIDTH_SCREEN, 1080, 0, 0, 0);
   
-  handlerProtagonista(&protagonista);
+  handlerProtagonista();
   handlerEnemies();
 
   return true;

--- a/src/screens/stage_4.c
+++ b/src/screens/stage_4.c
@@ -15,10 +15,10 @@ void destroyStage_4 () {
   al_destroy_bitmap(bg_stage_4);
 }
 
-bool drawStage_4 (struct AllegroGame *game, GameState *gameState) {
-  al_draw_bitmap_region(bg_stage_4, changeScreen(&protagonista, 4, gameState) * WIDTH_SCREEN , 0, WIDTH_SCREEN, 1080, 0, 0, 0);
+bool drawStage_4 () {
+  al_draw_bitmap_region(bg_stage_4, changeScreen(&protagonista, 4) * WIDTH_SCREEN , 0, WIDTH_SCREEN, 1080, 0, 0, 0);
   
-  handlerProtagonista(&protagonista, game);
+  handlerProtagonista(&protagonista);
   handlerEnemies();
 
   return true;

--- a/src/screens/stage_5.c
+++ b/src/screens/stage_5.c
@@ -15,10 +15,10 @@ void destroyStage_5 () {
   al_destroy_bitmap(bg_stage_5);
 }
 
-bool drawStage_5 (struct AllegroGame *game, GameState *gameState) {
-  al_draw_bitmap_region(bg_stage_5, changeScreen(&protagonista, 4, gameState) * WIDTH_SCREEN , 0, WIDTH_SCREEN, 1080, 0, 0, 0);
+bool drawStage_5 () {
+  al_draw_bitmap_region(bg_stage_5, changeScreen(&protagonista, 4) * WIDTH_SCREEN , 0, WIDTH_SCREEN, 1080, 0, 0, 0);
   
-  handlerProtagonista(&protagonista, game);
+  handlerProtagonista(&protagonista);
   handlerEnemies();
 
   return true;

--- a/src/screens/stage_5.c
+++ b/src/screens/stage_5.c
@@ -16,9 +16,9 @@ void destroyStage_5 () {
 }
 
 bool drawStage_5 () {
-  al_draw_bitmap_region(bg_stage_5, changeScreen(&protagonista, 4) * WIDTH_SCREEN , 0, WIDTH_SCREEN, 1080, 0, 0, 0);
+  al_draw_bitmap_region(bg_stage_5, changeScreen(4) * WIDTH_SCREEN , 0, WIDTH_SCREEN, 1080, 0, 0, 0);
   
-  handlerProtagonista(&protagonista);
+  handlerProtagonista();
   handlerEnemies();
 
   return true;

--- a/src/sound.c
+++ b/src/sound.c
@@ -6,8 +6,8 @@
 
 Sample samples[MAX_SAMPLES];
 
-void playSound(struct AllegroGame *game, int sample_index) {
-  if (!game->is_sound) {
+void playSound(int sample_index) {
+  if (!GAME_INFO->is_sound) {
     return;
   }
 


### PR DESCRIPTION
## Descrição

- **O que foi feito?**
 <!-- Descreva o que foi feito -->
Tranformei as variaveis `gameState`, `game` e `protagonista` como variavies globais.

A variavel `gamestate` foi renomeada para `state` e colocada dentro do `game` que foi renomeado para `GAME_INFO`

## Change type
<!-- Marque com um "x" o tipo da mudança -->

- [ ] fix
- [ ] Nova funcionalidade
- [ ] Documentação
- [x] Refatoração
- [ ] Outros